### PR TITLE
Add CesiumJS heatmap plugin

### DIFF
--- a/examples/cesium-heatmap/index.html
+++ b/examples/cesium-heatmap/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cesium Heatmap Plugin</title>
+    <link href="../../node_modules/cesium/Build/Cesium/Widgets/widgets.css" rel="stylesheet" />
+    <style>
+      html, body, #cesiumContainer {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+    </style>
+    <script src="/build/heatmap.js"></script>
+    <script src="../../node_modules/cesium/Build/Cesium/Cesium.js"></script>
+    <script src="/plugins/cesium-heatmap/cesium-heatmap.js"></script>
+  </head>
+  <body>
+    <div id="cesiumContainer"></div>
+    <script>
+      // initialize Cesium viewer
+      var viewer = new Cesium.Viewer('cesiumContainer', {
+        animation: false,
+        timeline: false
+      });
+      // rectangle in degrees: west, south, east, north
+      var rect = Cesium.Rectangle.fromDegrees(-120, 30, -110, 40);
+      // create heatmap overlay with 256x256 canvas
+      var ch = new CesiumHeatmap(viewer, rect, { size: 256 });
+      // add a single data point in the center
+      ch.addData({ x: 128, y: 128, value: 10 });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "grunt-contrib-watch": "0.2.0rc7",
     "grunt-contrib-jshint": ">= 0.3.0"
   },
+  "scripts": {
+    "test": "grunt jshint"
+  },
   "keywords": [
     "heatmap",
     "heatmaps",

--- a/plugins/cesium-heatmap/README.md
+++ b/plugins/cesium-heatmap/README.md
@@ -1,0 +1,21 @@
+# Cesium Heatmap Plugin
+
+This plugin lets you display [heatmap.js](https://www.patrick-wied.at/static/heatmapjs/) data inside a [CesiumJS](https://cesium.com/platform/cesiumjs/) globe. It converts the heatmap canvas into a `Cesium.SingleTileImageryProvider` so it can be added as an imagery layer.
+
+## Usage
+
+```html
+<script src="heatmap.min.js"></script>
+<script src="Cesium.js"></script>
+<script src="cesium-heatmap.js"></script>
+<script>
+  var viewer = new Cesium.Viewer('cesiumContainer');
+  var rect = Cesium.Rectangle.fromDegrees(-120, 30, -110, 40);
+  var ch = new CesiumHeatmap(viewer, rect, { size: 1024 });
+  ch.addData({ x: 512, y: 512, value: 10 });
+</script>
+```
+
+For a complete working example see [`examples/cesium-heatmap`](../../examples/cesium-heatmap).
+
+Data coordinates are in pixel space relative to the off‑screen canvas size (`options.size`). Update the heatmap using `addData`, `setData`, or `repaint`.

--- a/plugins/cesium-heatmap/cesium-heatmap.js
+++ b/plugins/cesium-heatmap/cesium-heatmap.js
@@ -1,0 +1,73 @@
+/*
+ * heatmap.js CesiumJS Overlay
+ *
+ * Provides a simple way to display heatmap.js data inside a CesiumJS globe
+ * by converting the canvas output to a single tile imagery layer.
+ */
+;(function (name, context, factory) {
+  // Supports UMD. AMD, CommonJS/Node.js and browser context
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory(
+      require('heatmap.js'),
+      require('cesium')
+    );
+  } else if (typeof define === 'function' && define.amd) {
+    define(['heatmap.js', 'cesium'], factory);
+  } else {
+    // browser globals
+    if (typeof window.h337 === 'undefined') {
+      throw new Error('heatmap.js must be loaded before the Cesium heatmap plugin');
+    }
+    if (typeof window.Cesium === 'undefined') {
+      throw new Error('CesiumJS must be loaded before the Cesium heatmap plugin');
+    }
+    context[name] = factory(window.h337, window.Cesium);
+  }
+})("CesiumHeatmap", this, function(h337, Cesium) {
+  'use strict';
+
+  function CesiumHeatmap(viewer, rectangle, options) {
+    this.viewer = viewer;
+    this.rectangle = rectangle; // Cesium.Rectangle in radians
+    this.options = options || {};
+
+    // off-screen container for heatmap.js renderer
+    var size = this.options.size || 1000;
+    var container = document.createElement('div');
+    container.style.width = size + 'px';
+    container.style.height = size + 'px';
+    this._container = container;
+
+    var heatmapOptions = Object.assign({ container: container }, this.options.heatmap || {});
+    this._heatmap = h337.create(heatmapOptions);
+    this._layer = null;
+  }
+
+  CesiumHeatmap.prototype._updateLayer = function() {
+    var dataURL = this._heatmap.getDataURL();
+    if (this._layer) {
+      this.viewer.imageryLayers.remove(this._layer, true);
+    }
+    this._layer = this.viewer.imageryLayers.addImageryProvider(new Cesium.SingleTileImageryProvider({
+      url: dataURL,
+      rectangle: this.rectangle
+    }));
+  };
+
+  CesiumHeatmap.prototype.addData = function(points) {
+    this._heatmap.addData(points);
+    this._updateLayer();
+  };
+
+  CesiumHeatmap.prototype.setData = function(data) {
+    this._heatmap.setData(data);
+    this._updateLayer();
+  };
+
+  CesiumHeatmap.prototype.repaint = function() {
+    this._heatmap.repaint();
+    this._updateLayer();
+  };
+
+  return CesiumHeatmap;
+});


### PR DESCRIPTION
## Summary
- add CesiumHeatmap plugin to display heatmaps on CesiumJS globes
- document usage of new plugin and provide example HTML

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx grunt jshint`
- `node verify Cesium plugin` (layers: 2)


------
https://chatgpt.com/codex/tasks/task_e_689ff996ef948333b26d807394f9b913